### PR TITLE
Applies Normalization to the DB

### DIFF
--- a/src/data_population/populate.py
+++ b/src/data_population/populate.py
@@ -20,17 +20,17 @@ ALLOWED_PREFIX = 'allowed' # max number of requests allowed per WINDOW_LENGTH
 
 # preparing a cursor object
 cursor_object = database.cursor()
-user_record = """SELECT * FROM subscription """
+user_record = """SELECT * FROM subscription_details """
 records = cursor_object.execute(user_record)
 result = cursor_object.fetchall()
 
 # >>> print(result)
-# [(1, 'test', 'Free', 2), (2, 'premium', 'Advanced', 200)]
-  
-print(result) # ToDo: Change this to logger
+# [('free_user', 'Free', 10, 1), ('basic_user', 'Basic', 100, 15), ('advanced_user', 'Advanced', 1000, 60), ('test', 'Advanced', 1000, 60)]
+
+logger.debug(result)
 database.close()
 
-for id, username, subscription_tier, request_limit in result:
+for username, subscription_tier, request_limit, retention_period in result:
   r.set(f'{ALLOWED_PREFIX}-{username}', request_limit)
 
 r.close()

--- a/src/subscription_db/schema.sql
+++ b/src/subscription_db/schema.sql
@@ -5,12 +5,36 @@ USE `DB`;
 DROP TABLE IF EXISTS `subscription`;
 CREATE TABLE `subscription` (
   `Id` int NOT NULL AUTO_INCREMENT,
-  `username` varchar(100) NOT NULL,
-  `subscription_tier` varchar(10) NOT NULL,
-  `request_limit` int NOT NULL,
+  `subscription_tier` varchar(10) NOT NULL UNIQUE,
+  `request_limit` int NOT NULL, -- Number of allowed requests per minute
+  `retention_period` int NOT NULL, -- Number of days the result should be stored in the backend
   PRIMARY KEY (`Id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
-alter table `subscription` add constraint ck_subscription_tier 
-   check (subscription_tier in ('Free', 'Basic', 'Advanced'));
-INSERT INTO `subscription` VALUES 
-(1, 'test', 'Free', 2), (2, 'premium', 'Advanced', 200);
+
+DROP TABLE IF EXISTS `auth`;
+CREATE TABLE auth (
+  `username` VARCHAR(20) PRIMARY KEY,
+  `password` VARCHAR(20) NOT NULL,
+  `subscription_tier` varchar(10) NOT NULL,
+  FOREIGN KEY (`subscription_tier`) REFERENCES `subscription`(`subscription_tier`)
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
+
+-- alter table `subscription` add constraint ck_subscription_tier 
+--    check (subscription_tier in ('Free', 'Basic', 'Advanced'));
+-- INSERT INTO `subscription` VALUES 
+-- (1, 'test', 'Free', 2), (2, 'premium', 'Advanced', 200);
+INSERT INTO `subscription` (`subscription_tier`, `request_limit`, `retention_period`) 
+VALUES 
+    ('Free', 10, 1),
+    ('Basic', 100, 15),
+    ('Advanced', 1000, 60);
+
+INSERT INTO `auth` (`username`, `password`, `subscription_tier`) 
+VALUES 
+('free_user', 'free', 'Free'), 
+('basic_user', 'basic', 'Basic'), 
+('advanced_user', 'advanced', 'Advanced'), 
+('test', 'test', 'Advanced');
+
+
+CREATE VIEW `subscription_details` AS SELECT a.username, s.subscription_tier, s.request_limit, s.retention_period FROM auth a INNER JOIN subscription s ON a.subscription_tier = s.subscription_tier;


### PR DESCRIPTION
- `subscription` table uses information relevant to subscription, and should be altered only by admin
- `auth` table uses information about users and can be altered by (auth service to insert/update user details, payent service to update subscription tier)

ToDo:
- Modify auth service to read from this DB
- Have separate DB for separate services and use saga pattern to insert/update the data.

References:
#60 #13 